### PR TITLE
Fix dataframe dtype assignment warnings

### DIFF
--- a/emodel_generalisation/adaptation.py
+++ b/emodel_generalisation/adaptation.py
@@ -71,13 +71,10 @@ def build_resistance_models(
     """Build resistance model of AIS/soma."""
     scales = get_scales(scales_params)
 
-    df = pd.DataFrame()
-    i = 0
-    for emodel in emodels:
-        for scale in scales:
-            df.loc[i, "emodel"] = emodel
-            df.loc[i, f"{key}_scaler"] = scale
-            i += 1
+    df = pd.DataFrame(
+        [(emodel, scale) for emodel in emodels for scale in scales],
+        columns=["emodel", f"{key}_scaler"],
+    )
     df["path"] = exemplar_data["paths"]["all"]
     df[f"{key}_model"] = json.dumps(exemplar_data[key])
 

--- a/emodel_generalisation/cli.py
+++ b/emodel_generalisation/cli.py
@@ -411,8 +411,14 @@ def evaluate(
         )
 
     if with_model_management:
-        exemplar_df = pd.DataFrame()
-        for gid, emodel in enumerate(cells_df.emodel.unique()):
+        exemplar_df = pd.DataFrame(
+            {
+                "emodel": pd.Series(dtype=str),
+                "path": pd.Series(dtype=str),
+                "name": pd.Series(dtype=str),
+            }
+        )
+        for gid, emodel in enumerate(cells_df.emodel.unique):
             morph = access_point.get_morphologies(emodel)
             exemplar_df.loc[gid, "emodel"] = emodel
             exemplar_df.loc[gid, "path"] = morph["path"]
@@ -628,7 +634,17 @@ def adapt(
 
     L.info("Extracting exemplar data...")
 
-    exemplar_df = pd.DataFrame()
+    exemplar_df = pd.DataFrame(
+        {
+            "emodel": pd.Series(dtype=str),
+            "path": pd.Series(dtype=str),
+            "name": pd.Series(dtype=str),
+            "ais_model": pd.Series(dtype=str),
+            "soma_model": pd.Series(dtype=str),
+            "soma_scaler": pd.Series(dtype=float),
+            "ais_scaler": pd.Series(dtype=float),
+        }
+    )
     for gid, emodel in enumerate(cells_df.emodel.unique()):
         if emodel != "no_emodel":
             morph = access_point.get_morphologies(emodel)


### PR DESCRIPTION
Example:
```
/gpfs/bbp.cscs.ch/project/proj30/tickets/NSETM-1760-wrap-snakemake-with-luigi/workflow-example/emodel-generalisation/emodel_generalisation/adaptation.py:78: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value 'emodel_1a1afc' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.
  df.loc[i, "emodel"] = emodel
```