### PR TITLE
Feat: Use distance twice in template for step distribution case

### DIFF
--- a/emodel_generalisation/templates/cell_template_neurodamus.jinja2
+++ b/emodel_generalisation/templates/cell_template_neurodamus.jinja2
@@ -187,7 +187,8 @@ proc distribute_distance(){local x localobj sl
   this.soma[0] distance(0, 0.5)
   sprint(distfunc, "%%s %s(%%f) = %s", mech, distfunc)
   forsec sl for(x, 0) {
-    sprint(stmp, distfunc, secname(), x, distance(x))
+    // use distance(x) twice for the step distribution case, e.g. for calcium hotspot
+    sprint(stmp, distfunc, secname(), x, distance(x), distance(x))
     execute(stmp)
   }
 }

--- a/emodel_generalisation/templates/cell_template_neurodamus_placeholder.jinja2
+++ b/emodel_generalisation/templates/cell_template_neurodamus_placeholder.jinja2
@@ -182,7 +182,8 @@ proc distribute_distance(){local x localobj sl
   this.soma[0] distance(0, 0.5)
   sprint(distfunc, "%%s %s(%%f) = %s", mech, distfunc)
   forsec sl for(x, 0) {
-    sprint(stmp, distfunc, secname(), x, distance(x))
+    // use distance(x) twice for the step distribution case, e.g. for calcium hotspot
+    sprint(stmp, distfunc, secname(), x, distance(x), distance(x))
     execute(stmp)
   }
 }


### PR DESCRIPTION
use distance twice in jinja template for step distribution case

### Description
Step distributions need to have distance twice in the hoc file in order to be usable.
This does not affect other distributions, they will still be working as before.
This was already implemented in BluePyOpt and BluePyEModel (see e.g. https://github.com/BlueBrain/BluePyOpt/blob/master/bluepyopt/ephys/templates/cell_template.jinja2#L127)

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the issue).
	- [ ] Please include tests that fail with the `main` branch and pass with the provided fix.
- [x] A new feature implementation or update an existing feature
	- [ ] Please include: `Fixes: #<issue number>` in the description if it solves an existing issue
	  (which must include a complete example of the feature).
	- [ ] Please include tests that cover every lines of the new/updated feature.
	- [ ] Please update the documentation to describe the new/updated feature.

<!-- **Have a nice day!** -->
